### PR TITLE
Torna configurável o caminho de "serial" que até então é considerado …

### DIFF
--- a/config.ini-TEMPLATE
+++ b/config.ini-TEMPLATE
@@ -4,6 +4,9 @@
 ## contains the directories proc, bases, htdocs, cgi-bin, serial.
 source_dir=/var/www/scielo
 
+## contains the directory: serial. Configure if source_dir has no serial folder
+#serial_source_dir=/scielo
+
 ## Full path to the CISIS utilitaries. It is usually installed on the directory
 ## proc/cisis of the SciELO Site.
 cisis_dir=/var/www/scielo/proc/cisis

--- a/paperboy/send_to_server.py
+++ b/paperboy/send_to_server.py
@@ -133,6 +133,7 @@ class Delivery(object):
         self.cisis_dir = remove_last_slash(cisis_dir)
         self.source_type = source_type
         self.source_dir = remove_last_slash(source_dir)
+        self.serial_source_dir = self.source_dir
         self.destiny_dir = remove_last_slash(destiny_dir)
         self.compatibility_mode = compatibility_mode
 
@@ -204,12 +205,12 @@ class Delivery(object):
             path += u'/' + item
             self.client.mkdir(self.destiny_dir + path)
 
-        # Cria recursivamente todo conteudo baixo o source_dir + base_path
-        tree = os.walk(self.source_dir + u'/' + base_path)
+        # Cria recursivamente todo conteudo baixo o serial_source_dir + base_path
+        tree = os.walk(self.serial_source_dir + u'/' + base_path)
         converted = set()
         for item in tree:
             root = item[0].replace(u'\\', u'/')
-            current = root.replace(self.source_dir + u'/', u'')
+            current = root.replace(self.serial_source_dir + u'/', u'')
             dirs = item[1]
             files = item[2]
 
@@ -417,6 +418,12 @@ def main():
         default=setts.get(u'source_dir', u'.'),
         help=u'absolute path where the SciELO site was installed. this directory must contain the directories bases, htcos, proc and serial'
     )
+    parser.add_argument(
+        u'--serial_source_dir',
+        u'-s',
+        default=setts.get(u'serial_source_dir', ''),
+        help=u'absolute path where the SciELO site was installed. this directory must contain the serial directory'
+    )
 
     parser.add_argument(
         u'--destiny_dir',
@@ -492,5 +499,6 @@ def main():
         args.user,
         args.password
     )
+    delivery.serial_source_dir = args.serial_source_dir or args.source_dir
 
     delivery.run()


### PR DESCRIPTION
…o mesmo de onde está o site local

#### O que esse PR faz?
Torna configurável o caminho de "serial" que até então é considerado o mesmo de onde está o site local

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
executando o paperboy, com a configuração de `serial_source_dir`

#### Algum cenário de contexto que queira dar?
Este problema é particular do send_to_server.

### Screenshots
n/a

#### Quais são tickets relevantes?
#10

### Referências
n/a
