### PR TITLE
Normaliza o caminho do `serial_source_dir`

### DIFF
--- a/paperboy/send_to_server.py
+++ b/paperboy/send_to_server.py
@@ -127,7 +127,6 @@ class Delivery(object):
 
     def __init__(self, source_type, cisis_dir, scilista, source_dir, destiny_dir,
             compatibility_mode, server, server_type, port, user, password):
-        self._serial_source_dir = None
         self._scilista = parse_scilista(scilista)
         self.scilista = scilista
         self.cisis_dir = remove_last_slash(cisis_dir)
@@ -146,11 +145,11 @@ class Delivery(object):
 
     @property
     def serial_source_dir(self):
-        return self._serial_source_dir
+        return self._serial_source_dir or self.source_dir
 
     @serial_source_dir.setter
     def serial_source_dir(self, value):
-        self._serial_source_dir = remove_last_slash(value)
+        self._serial_source_dir = remove_last_slash(value) if value else self.source_dir
 
     def _local_remove(self, path):
 
@@ -507,6 +506,6 @@ def main():
         args.user,
         args.password
     )
-    delivery.serial_source_dir = args.serial_source_dir or args.source_dir
+    delivery.serial_source_dir = args.serial_source_dir
 
     delivery.run()

--- a/paperboy/send_to_server.py
+++ b/paperboy/send_to_server.py
@@ -126,13 +126,13 @@ def remove_last_slash(path):
 class Delivery(object):
 
     def __init__(self, source_type, cisis_dir, scilista, source_dir, destiny_dir,
-            compatibility_mode, server, server_type, port, user, password):
+            compatibility_mode, server, server_type, port, user, password, serial_source_dir=None):
         self._scilista = parse_scilista(scilista)
         self.scilista = scilista
         self.cisis_dir = remove_last_slash(cisis_dir)
         self.source_type = source_type
         self.source_dir = remove_last_slash(source_dir)
-        self.serial_source_dir = self.source_dir
+        self.serial_source_dir = remove_last_slash(serial_source_dir) if serial_source_dir else self.source_dir
         self.destiny_dir = remove_last_slash(destiny_dir)
         self.compatibility_mode = compatibility_mode
 
@@ -142,14 +142,6 @@ class Delivery(object):
             self.client = FTP(server, int(port), user, password)
         else:
             raise TypeError(u'server_type must be ftp or sftp')
-
-    @property
-    def serial_source_dir(self):
-        return self._serial_source_dir or self.source_dir
-
-    @serial_source_dir.setter
-    def serial_source_dir(self, value):
-        self._serial_source_dir = remove_last_slash(value) if value else self.source_dir
 
     def _local_remove(self, path):
 
@@ -504,8 +496,7 @@ def main():
         args.server_type,
         args.port,
         args.user,
-        args.password
+        args.password,
+        args.serial_source_dir
     )
-    delivery.serial_source_dir = args.serial_source_dir
-
     delivery.run()

--- a/paperboy/send_to_server.py
+++ b/paperboy/send_to_server.py
@@ -127,7 +127,7 @@ class Delivery(object):
 
     def __init__(self, source_type, cisis_dir, scilista, source_dir, destiny_dir,
             compatibility_mode, server, server_type, port, user, password):
-
+        self._serial_source_dir = None
         self._scilista = parse_scilista(scilista)
         self.scilista = scilista
         self.cisis_dir = remove_last_slash(cisis_dir)
@@ -143,6 +143,14 @@ class Delivery(object):
             self.client = FTP(server, int(port), user, password)
         else:
             raise TypeError(u'server_type must be ftp or sftp')
+
+    @property
+    def serial_source_dir(self):
+        return self._serial_source_dir
+
+    @serial_source_dir.setter
+    def serial_source_dir(self, value):
+        self._serial_source_dir = remove_last_slash(value)
 
     def _local_remove(self, path):
 


### PR DESCRIPTION
Corrige o erro abaixo causado por não ter passado o `serial_source_dir` pela função `remove_last_slash`.

Ao executar o paperboy, aconteceu um erro

```
2020-02-21 07:56:04,282 - paperboy.send_to_server - DEBUG - Running: C:/scielo/web/proc/cisis/crunchmf C:/scielo/serial/issue/issue C:/scielo/serial/issue/issue_converted
2020-02-21 07:56:04,282 - paperboy.send_to_server - DEBUG - Running: C:/scielo/web/proc/cisis/crunchmf C:/scielo/serial/issue/issue C:/scielo/serial/issue/issue_converted
2020-02-21 07:56:04,361 - paperboy.send_to_server - DEBUG - Conversion done for C:/scielo/serial/issue/issue
2020-02-21 07:56:04,361 - paperboy.send_to_server - DEBUG - Conversion done for C:/scielo/serial/issue/issue
2020-02-21 07:56:04,362 - paperboy.communicator - INFO - Copying file from (C:/scielo/serial/issue/issue_converted.mst) to (./C:/scielo/serial/issue/issue.mst)
2020-02-21 07:56:04,362 - paperboy.communicator - INFO - Copying file from (C:/scielo/serial/issue/issue_converted.mst) to (./C:/scielo/serial/issue/issue.mst)
Traceback (most recent call last):
  File "C:\Python27\Scripts\paperboy_delivery_to_server-script.py", line 11, in <module>
    load_entry_point('scielo-paperboy', 'console_scripts', 'paperboy_delivery_to_server')()
  File "c:\users\bibli\src\paperboy\paperboy\send_to_server.py", line 504, in main
    delivery.run()
  File "c:\users\bibli\src\paperboy\paperboy\send_to_server.py", line 379, in run
    self.run_serial()
  File "c:\users\bibli\src\paperboy\paperboy\send_to_server.py", line 261, in run_serial
    self.transfer_data_databases(u'serial/issue')
  File "c:\users\bibli\src\paperboy\paperboy\send_to_server.py", line 247, in transfer_data_databases
    self.client.put(from_fl + u'.' + extension, to_fl + u'.' + extension)
  File "c:\users\bibli\src\paperboy\paperboy\communicator.py", line 94, in put
    command.encode('utf-8'), open(from_fl, read_type)
  File "c:\python27\lib\ftplib.py", line 479, in storbinary
    conn = self.transfercmd(cmd, rest)
  File "c:\python27\lib\ftplib.py", line 378, in transfercmd
    return self.ntransfercmd(cmd, rest)[0]
  File "c:\python27\lib\ftplib.py", line 341, in ntransfercmd
    resp = self.sendcmd(cmd)
  File "c:\python27\lib\ftplib.py", line 251, in sendcmd
    return self.getresp()
  File "c:\python27\lib\ftplib.py", line 226, in getresp
    raise error_perm, resp
ftplib.error_perm: 553 Could not create file.
```

Na linha
```
2020-02-21 07:56:04,362 - paperboy.communicator - INFO - Copying file from (C:/scielo/serial/issue/issue_converted.mst) to (./C:/scielo/serial/issue/issue.mst)

```

seria esperado 
```
2020-02-21 07:56:04,362 - paperboy.communicator - INFO - Copying file from (C:/scielo/serial/issue/issue_converted.mst) to (./serial/issue/issue.mst)
```